### PR TITLE
Prevevent deprecation warning with ansible 2.4

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,7 +57,7 @@
       (apparmor__enabled|d() | bool) and
       (ansible_cmdline.apparmor|d(0)|string == "1") and
       (ansible_cmdline.security|d("none") == "apparmor") }}'
-  always_run: True
+  check_mode: no
 
 - name: Flush the handlers in case the next tasks fails
   meta: flush_handlers


### PR DESCRIPTION
[DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead.. This feature will be removed in version 2.4. Deprecation 
warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.