### PR TITLE
Update main.yml because of error with always_run

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,7 +57,7 @@
       (apparmor__enabled|d() | bool) and
       (ansible_cmdline.apparmor|d(0)|string == "1") and
       (ansible_cmdline.security|d("none") == "apparmor") }}'
-  always_run: True
+  check_mode: no
 
 - name: Flush the handlers in case the next tasks fails
   meta: flush_handlers


### PR DESCRIPTION
Since Ansible 2.6 `always_run` is deprecated [1] and replaced by `check_mode: no`.

Got this error when running a playbook:

```
ERROR! 'always_run' is not a valid attribute for a Task

The error appears to have been in '/Users/henningwaack/.ansible/roles/debops-contrib.apparmor/tasks/main.yml': line 54, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


- name: Check if the running kernel has been started with AppArmor enabled
  ^ here
```

[1] - https://docs.ansible.com/ansible/2.6/porting_guides/porting_guide_2.6.html