### PR TITLE
Replaced filters removed in ansible 2.9.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,7 +21,7 @@ apparmor__base_packages:
   - 'apparmor-utils'
   - 'apparmor-profiles'
   - '{{ []
-        if (ansible_distribution == "Ubuntu" and ansible_distribution_version is not version("15.10", ">=")))
+        if (ansible_distribution == "Ubuntu" and ansible_distribution_version is not version("15.10", ">="))
         else [ "apparmor-profiles-extra" ] }}'
 
                                                                    # ]]]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,7 +21,7 @@ apparmor__base_packages:
   - 'apparmor-utils'
   - 'apparmor-profiles'
   - '{{ []
-        if (ansible_distribution == "Ubuntu" and not (ansible_distribution_version|version_compare("15.10", ">=")))
+        if (ansible_distribution == "Ubuntu" and ansible_distribution_version is not version("15.10", ">=")))
         else [ "apparmor-profiles-extra" ] }}'
 
                                                                    # ]]]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -134,14 +134,14 @@
 
 - name: Reload changed profiles
   command: apparmor_parser --replace "/etc/apparmor.d/{{ item.item.key }}"
-  when: (item|changed and not apparmor__register_tunables|changed)
+  when: (item is changed and apparmor__register_tunables is not changed)
   with_items: '{{ apparmor__register_local_config.results }}'
 
 - name: Reload AppArmor all profiles
   service:
     name: 'apparmor'
     state: 'reloaded'
-  when: apparmor__fact_apparmor_enabled_and_loaded|bool and apparmor__register_tunables|changed
+  when: apparmor__fact_apparmor_enabled_and_loaded|bool and apparmor__register_tunables is changed
 
 - name: Unload AppArmor profiles
   command: service apparmor teardown


### PR DESCRIPTION
Using tests as filters was deprecated in ansible 2.5 and now, moving to 2.9 have been removed. Also, version_compare was renamed in 2.5 as well. 

Please consider including this to upstream.